### PR TITLE
Fix tacker-horizon branch (not master)

### DIFF
--- a/devstack/lib/tacker
+++ b/devstack/lib/tacker
@@ -40,7 +40,7 @@ fi
 
 # Set up default directories
 GITREPO["tacker-horizon"]=${TACKERHORIZON_REPO:-${GIT_BASE}/openstack/tacker-horizon.git}
-GITBRANCH["tacker-horizon"]=${TACKERHORIZON_BRANCH:-master}
+GITBRANCH["tacker-horizon"]=${TACKERHORIZON_BRANCH:-stable/ocata}
 GITDIR["tacker-horizon"]=$DEST/tacker-horizon
 
 TACKER_DIR=$DEST/tacker


### PR DESCRIPTION
Hi Tackers!
L43: master was incorrect, currently tacker remains in 0.7.0 but tacker-horizon has been committed in 0.8.0 and requires new modules version : this leads to version conflict (pbr > 2.0.0)  pbr 1.10.0 is used in ocata.
BR.